### PR TITLE
feat: paginate entire query

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Scan your email for treachery
 - [x] Fix build
 - [x] Make `yarn test` run frontend tests and linting too
 - [x] List TODOs command
-- [ ] Implement pagination in fetch emails
+- [x] Implement pagination in fetch emails
 - [x] Fix files with pre-commit hook
 
 # Stretch Goals

--- a/src/gmail/__mocks__/api.ts
+++ b/src/gmail/__mocks__/api.ts
@@ -1,16 +1,19 @@
 import { GmailClient, Message } from '../../types';
 
-export async function listMessages(_client: GmailClient): Promise<Message[]> {
-  return [
-    { id: '1', threadId: '1' },
-    { id: '2', threadId: '2' },
-    { id: '3', threadId: '3' },
-  ];
+export async function listMessages(
+  _client: GmailClient,
+  _query: string,
+  pageToken?: string,
+): Promise<{ messages: Message[]; nextPageToken?: string }> {
+  if (!pageToken) return { messages: [{ id: '1', threadId: '1' }], nextPageToken: 'page_2' };
+  if (pageToken === 'page_2') return { messages: [{ id: '2', threadId: '2' }], nextPageToken: 'page_3' };
+  if (pageToken === 'page_3') return { messages: [{ id: '3', threadId: '3' }] };
+  throw new Error('Received an invalid page token in a test');
 }
 
 export async function getMessage(
   _client: GmailClient,
-  id: string
+  id: string,
 ): Promise<Message> {
   return { id, raw: 'hydrated_gmail_message' };
 }

--- a/src/gmail/api.ts
+++ b/src/gmail/api.ts
@@ -12,14 +12,27 @@ export async function listThreads(client: GmailClient): Promise<Thread[]> {
 }
 
 /**
- * Get the first page of messages from the currently signed-in user's inbox.
+ * Get a page of messages from the currently signed-in user's inbox.
  * @param client An authorized GmailClient
+ * @param query The Gmail search query to use to filter the results
+ * @param pageToken If not provided, retrieves the first page of results. If provided, retrieves
+ * the page of results following the query page that returned the token.
  */
-export async function listMessages(client: GmailClient): Promise<Message[]> {
-  const resp = await client.users.messages.list({ userId: 'me' });
-  const { messages } = resp.data;
-  if (!messages) return [];
-  return messages;
+export async function listMessages(
+  client: GmailClient,
+  query: string,
+  pageToken?: string,
+): Promise<{ messages: Message[]; nextPageToken?: string }> {
+  const resp = await client.users.messages.list({
+    userId: 'me',
+    q: query,
+    pageToken,
+  });
+  const { messages, nextPageToken } = resp.data;
+  return {
+    messages: messages || [],
+    nextPageToken: nextPageToken || undefined,
+  };
 }
 
 /**

--- a/src/workers/persist.spec.ts
+++ b/src/workers/persist.spec.ts
@@ -142,7 +142,7 @@ describe('message db tests', () => {
     it('persists messages that do not yet exist in the database', async () => {
       const fakeClient = (null as unknown) as GmailClient;
       const result = await persist(fakeClient);
-      expect(result).toEqual({ listed: 3, saved: 2 });
+      expect(result).toEqual({ pages: 3, listed: 3, saved: 2 });
       expect(await Message.count()).toEqual(3);
       expect(await Message.findOne({ gmailId: '1' })).toMatchObject({
         gmailId: '1',

--- a/src/workers/persist.ts
+++ b/src/workers/persist.ts
@@ -90,6 +90,7 @@ export async function persistAll(messages: GmailMessage[]): Promise<number> {
  * (`messages.get`, unseen emails we retrieved and persisted in the database).
  *
  * @param client The Gmail client to be used to access the user's inbox
+ * @param query The Gmail query to be used to list messages. Defaults to messages in the inbox.
  */
 export default async function persist(
   client: GmailClient,


### PR DESCRIPTION
`persist()` now loads all emails from the user's inbox, not just the first page.