### PR TITLE
Don't stem long things that are not words

### DIFF
--- a/src/lib/classify.ts
+++ b/src/lib/classify.ts
@@ -46,6 +46,12 @@ function countUniqueStrings(arr: string[]): StrNum {
  * @param word The word to be stemmed
  */
 export function stem(word: string): string {
+  // HACK: This is due to us not properly stripping stuff like sourcemappingurl=... and leaving
+  // contents of <style> tags in the email extracted content
+  if (word.length > 100) {
+    console.warn(`Unstemmable word: ${word.slice(0, 40)}...`);
+    return '';
+  }
   return stemmer(word);
 }
 


### PR DESCRIPTION
I'm seeing CPU starvation on stemming of degenerate strings that make it into the list of words to classify, e.g. `sourcemappingurl=data:application/json;charset=utf8;base64,eyj2zxjzaw9uijozlcjmawxlijoibwnklxn0ewxlcy5jc3mi...`.

As a holdover, this returns empty strings which will be ignored during classification for words we think could crash the stemmer.