### PR TITLE
Show keywords in frontend

### DIFF
--- a/fixtures/fake_received_headers.json
+++ b/fixtures/fake_received_headers.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name": "Received",
+    "value": "by 127.0.0.1 with SMTP id deadbeefcafe;        Fri, 17 Apr 2020 18:02:07 -0700 (PDT)"
+  }
+]

--- a/frontend/src/components/Details.spec.ts
+++ b/frontend/src/components/Details.spec.ts
@@ -12,11 +12,25 @@ describe('Details', () => {
           suspicion: 0.201,
           body: 'this is a fake email body!',
         },
+        keywords: {
+          virus: {
+            description: 'Concerning viruses and disease transmission',
+            keywords: ['covid19', 'flu', 'pneumonia'],
+          },
+          scarewords: {
+            description: "Intended to lower the reader's guard",
+            keywords: ['act now', 'danger', 'immediate'],
+          },
+        },
       },
     });
     expect(wrapper.html()).toMatchInlineSnapshot(`
       <div class="details">
         <h1>Details</h1>
+        <b-row>
+          <b-col cols="4" class="left">Date</b-col>
+          <b-col cols="8" class="right"></b-col>
+        </b-row>
         <b-row>
           <b-col cols="4" class="left">From</b-col>
           <b-col cols="8" class="right">scammer@spamsite.xyz</b-col>
@@ -27,16 +41,9 @@ describe('Details', () => {
         </b-row>
         <b-row class="tags">
           <b-col cols="4" class="left">Tags</b-col>
-          <b-col cols="8" class="right">
-            <ul>
-              <li>
-                virus
-              </li>
-              <li>
-                scarewords
-              </li>
-            </ul>
-          </b-col>
+          <b-col cols="8" class="right"><span><details><summary>virus</summary> <p>Concerning viruses and disease transmission</p> <p>
+                  Includes: <em>covid19, flu, pneumonia</em></p></details><details><summary>scarewords</summary> <p>Intended to lower the reader's guard</p> <p>
+                  Includes: <em>act now, danger, immediate</em></p></details></span></b-col>
         </b-row>
         <b-row class="evenRow">
           <b-col cols="4" class="left">Suspicion</b-col>

--- a/frontend/src/components/Details.vue
+++ b/frontend/src/components/Details.vue
@@ -2,6 +2,10 @@
   <div class="details">
     <h1>Details</h1>
     <b-row>
+      <b-col class="left" cols="4">Date</b-col>
+      <b-col class="right" cols="8">{{ details.receivedAt }}</b-col>
+    </b-row>
+    <b-row>
       <b-col class="left" cols="4">From</b-col>
       <b-col class="right" cols="8">{{ details.from }}</b-col>
     </b-row>
@@ -35,6 +39,7 @@ import 'reflect-metadata';
 import { Vue, Component, Prop } from 'vue-property-decorator';
 
 interface DetailsProps {
+  receivedAt: Date;
   from: string;
   subject: string;
   tags: string[];

--- a/frontend/src/components/Details.vue
+++ b/frontend/src/components/Details.vue
@@ -16,11 +16,16 @@
     <b-row class="tags">
       <b-col class="left" cols="4">Tags</b-col>
       <b-col class="right" cols="8">
-        <ul>
-          <li v-for="(tag, i) in details.tags" :key="i">
-            {{ tag }}
-          </li>
-        </ul>
+        <span v-if="details.tags.length > 0">
+          <details v-for="(tag, i) in details.tags" :key="i">
+            <summary>{{ tag }}</summary>
+            <p>{{ keywords[tag].description }}</p>
+            <p>
+              Includes: <em>{{ keywords[tag].keywords.join(', ') }}</em>
+            </p>
+          </details>
+        </span>
+        <span v-else><em>No tags</em></span>
       </b-col>
     </b-row>
     <b-row class="evenRow">
@@ -37,6 +42,7 @@
 <script lang="ts">
 import 'reflect-metadata';
 import { Vue, Component, Prop } from 'vue-property-decorator';
+import { Keywords } from '../../../src/types';
 
 interface DetailsProps {
   receivedAt: Date;
@@ -50,6 +56,8 @@ interface DetailsProps {
 @Component
 export default class Details extends Vue {
   @Prop() readonly details!: DetailsProps;
+
+  @Prop() readonly keywords!: Keywords;
 }
 </script>
 
@@ -68,9 +76,8 @@ h1
   background: rgba(0, 0, 0, 0.04)
 
 .tags
-  ul
+  p
     margin-bottom: 0px
-    padding-left: 14px
 
 .left
   text-align: right

--- a/frontend/src/views/Inbox.vue
+++ b/frontend/src/views/Inbox.vue
@@ -43,7 +43,7 @@
         </b-row>
       </b-col>
       <b-col cols="8">
-        <Details v-if="message" :details="message" />
+        <Details v-if="message" :keywords="keywords" :details="message" />
         <p v-else>Select a message to view.</p>
       </b-col>
     </b-row>
@@ -95,8 +95,7 @@ async function fetchJsonRetry(url: string): Promise<any> {
 }
 
 async function loadKeywords(): Promise<Keywords> {
-  const resp = await fetchJsonRetry('//localhost:9999/keywords');
-  return resp.json();
+  return fetchJsonRetry('//localhost:9999/keywords');
 }
 
 async function loadPageCount(): Promise<number> {

--- a/frontend/src/views/Inbox.vue
+++ b/frontend/src/views/Inbox.vue
@@ -156,13 +156,10 @@ export default class Inbox extends Vue {
   async loadPage(page: number): Promise<void> {
     this.deselect();
     this.page = page;
-    console.log('loading page', page);
     if (this.messages) return;
     const pageData = await loadEmails(page);
-    console.log('assigning to:', page, pageData);
     this.pagesOfMessages[this.page] = pageData;
     this.$set(this.pagesOfMessages, this.page, pageData);
-    console.log('done:', this.pagesOfMessages);
   }
 
   show(i: number): void {

--- a/frontend/src/views/Inbox.vue
+++ b/frontend/src/views/Inbox.vue
@@ -137,11 +137,6 @@ export default class Inbox extends Vue {
   }
 
   get messages(): EmailResponse[] {
-    console.log({
-      all: this.pagesOfMessages,
-      data: this.pagesOfMessages[this.page],
-      page: this.page,
-    });
     return this.pagesOfMessages[this.page];
   }
 

--- a/frontend/src/views/Inbox.vue
+++ b/frontend/src/views/Inbox.vue
@@ -92,11 +92,11 @@ async function fetchJsonRetry(url: string): Promise<any> {
   /* eslint-enable no-await-in-loop */
 }
 
-async function getPageCount(): Promise<number> {
+async function loadPageCount(): Promise<number> {
   return fetchJsonRetry('//localhost:9999/emails/count');
 }
 
-async function getEmails(page: number): Promise<EmailResponse[]> {
+async function loadEmails(page: number): Promise<EmailResponse[]> {
   const url = urlWithQs('//localhost:9999/emails', {
     offset: page * PAGE_SIZE,
     limit: PAGE_SIZE,
@@ -152,7 +152,7 @@ export default class Inbox extends Vue {
   }
 
   async mounted(): Promise<void> {
-    this.messageCount = await getPageCount();
+    this.messageCount = await loadPageCount();
     this.pageCount = Math.ceil(this.messageCount / PAGE_SIZE);
     await this.loadPage(this.page);
   }
@@ -162,7 +162,7 @@ export default class Inbox extends Vue {
     this.page = page;
     console.log('loading page', page);
     if (this.messages) return;
-    const pageData = await getEmails(page);
+    const pageData = await loadEmails(page);
     console.log('assigning to:', page, pageData);
     this.pagesOfMessages[this.page] = pageData;
     this.$set(this.pagesOfMessages, this.page, pageData);

--- a/frontend/src/views/Inbox.vue
+++ b/frontend/src/views/Inbox.vue
@@ -18,10 +18,11 @@
       <b-col cols="4">
         <b-row class="paginator">
           <b-col>
-            <button @click="prevPage" :disabled="!canPrevPage">&laquo;</button
-            ><span class="status"
+            <button @click="prevPage" :disabled="!canPrevPage">&laquo;</button>
+            <span class="status"
               >{{ pageStart + 1 }} to {{ pageEnd }} of {{ messageCount }}</span
-            ><button @click="nextPage" :disabled="!canNextPage">&raquo;</button>
+            >
+            <button @click="nextPage" :disabled="!canNextPage">&raquo;</button>
           </b-col>
         </b-row>
         <span v-if="messages">
@@ -191,33 +192,44 @@ export default class Inbox extends Vue {
 </script>
 
 <style lang="stylus">
-bright-blue = #3498db // Flat UI Colors: Peter River
-dark-blue = #2980b9 // Flat UI Colors: Belize Hole
+bright-blue = #3498db; // Flat UI Colors: Peter River
+dark-blue = #2980b9; // Flat UI Colors: Belize Hole
 
-nav
-  width: 100%
+nav {
+  width: 100%;
+}
 
-.loading
-  font-style: italic
+.loading {
+  font-style: italic;
+}
 
-.paginator
-  text-align: center
-  margin-bottom: 8px
-  .status
-    display: inline-block
-    min-width: 120px
-    margin-left: 8px
-    margin-right: 8px
-  button
-    border: none
-    border-radius: 4px
-    color: white
-    font-weight: 800
-    padding: 3px 10px
-    background: bright-blue
-    &:hover
-      background: dark-blue
-    &:disabled
-      color: rgba(0, 0, 0, 0.2)
-      background-color: rgba(0, 0, 0, 0.1)
+.paginator {
+  text-align: center;
+  margin-bottom: 8px;
+
+  .status {
+    display: inline-block;
+    min-width: 120px;
+    margin-left: 8px;
+    margin-right: 8px;
+  }
+
+  button {
+    border: none;
+    border-radius: 4px;
+    color: white;
+    font-weight: 800;
+    padding: 3px 10px;
+    background: bright-blue;
+
+    &:hover {
+      background: dark-blue;
+    }
+
+    &:disabled {
+      color: rgba(0, 0, 0, 0.2);
+      background-color: rgba(0, 0, 0, 0.1);
+    }
+  }
+}
 </style>

--- a/frontend/src/views/Inbox.vue
+++ b/frontend/src/views/Inbox.vue
@@ -58,6 +58,7 @@ import { stringify } from 'query-string';
 import { EmailResponse } from '../types';
 import Summary from '../components/Summary.vue';
 import Details from '../components/Details.vue';
+import { Keywords } from '../../../src/types';
 
 /**
  * Number of times to retry getting emails
@@ -93,6 +94,11 @@ async function fetchJsonRetry(url: string): Promise<any> {
   /* eslint-enable no-await-in-loop */
 }
 
+async function loadKeywords(): Promise<Keywords> {
+  const resp = await fetchJsonRetry('//localhost:9999/keywords');
+  return resp.json();
+}
+
 async function loadPageCount(): Promise<number> {
   return fetchJsonRetry('//localhost:9999/emails/count');
 }
@@ -110,6 +116,8 @@ async function loadEmails(page: number): Promise<EmailResponse[]> {
   components: { Summary, Details },
 })
 export default class Inbox extends Vue {
+  keywords: Keywords = {};
+
   pagesOfMessages: EmailResponse[][] = [];
 
   currMessageIndex: number | null = null;
@@ -148,6 +156,9 @@ export default class Inbox extends Vue {
   }
 
   async mounted(): Promise<void> {
+    loadKeywords().then((keywords) => {
+      this.keywords = keywords;
+    });
     this.messageCount = await loadPageCount();
     this.pageCount = Math.ceil(this.messageCount / PAGE_SIZE);
     await this.loadPage(this.page);

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:jest": "scripts/use_db.js test && jest --coverage --runInBand",
     "test:lint": "eslint src/**/*.ts",
     "test:frontend": "scripts/test_frontend.sh",
-    "test:watch": "scripts/use_db.js test && jest --watch",
+    "test:watch": "scripts/use_db.js test && jest --watch --runInBand",
     "doc": "run-s doc:html && open-cli build/docs/index.html",
     "doc:html": "typedoc src/ --exclude **/*.spec.ts --target ES6 --mode file --out build/docs",
     "doc:json": "typedoc src/ --exclude **/*.spec.ts --target ES6 --mode file --json build/docs/typedoc.json",

--- a/src/entities/message.ts
+++ b/src/entities/message.ts
@@ -14,6 +14,9 @@ export default class Message extends BaseEntity {
   @Column('jsonb')
   data!: GmailMessage;
 
+  @Column('timestamptz', { name: 'received_at' })
+  receivedAt!: Date;
+
   @Column('timestamptz', { name: 'tagged_at', nullable: true })
   taggedAt?: Date;
 

--- a/src/gmail/__mocks__/api.ts
+++ b/src/gmail/__mocks__/api.ts
@@ -1,4 +1,5 @@
 import { GmailClient, Message } from '../../types';
+import FAKE_RECEIVED_HEADERS from '../../../fixtures/fake_received_headers.json';
 
 export async function listMessages(
   _client: GmailClient,
@@ -15,5 +16,9 @@ export async function getMessage(
   _client: GmailClient,
   id: string,
 ): Promise<Message> {
-  return { id, raw: 'hydrated_gmail_message' };
+  return {
+    id,
+    raw: 'hydrated_gmail_message',
+    payload: { headers: FAKE_RECEIVED_HEADERS },
+  };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,15 +7,19 @@ import Message from './entities/message';
 import { extractPlaintextContent } from './lib/content';
 import { EmailResponse } from './types';
 import { headerPairsToHash } from './lib/util';
-import classify from './workers/classify';
+import classify, { RAW_KEYWORDS_YAML } from './workers/classify';
 import persist from './workers/persist';
 import { createClient, installRouter } from './lib/auth';
+import { parseKeywordLists } from './lib/classify';
 
 const DEFAULT_PORT = 9999;
 const ORIGIN = 'http://localhost:8080'; // HACK: This only works with the Vue dev server for now
 const WORKER_INTERVAL = 5 * 60 * 1000; // 5m
 
 const DEFAULT_PAGE_COUNT = 10;
+
+// HACK: This import is silly. Revisit it
+const { keywords: KEYWORDS } = parseKeywordLists(RAW_KEYWORDS_YAML);
 
 let workersStarted = false;
 
@@ -95,6 +99,9 @@ async function createApp(): Promise<Express> {
   app.get('/emails/count', async (_req, res) => {
     const count = await Message.count();
     res.json(count);
+  });
+  app.get('/keywords', async (_req, res) => {
+    res.json(KEYWORDS);
   });
   return app;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ function numPlucker(query: Query) {
 
 function convertMessage(message: Message): EmailResponse {
   const {
-    id, gmailId, data, tags,
+    id, gmailId, data, tags, receivedAt,
   } = message;
   const headersRaw = data.payload?.headers;
   if (!headersRaw) throw new Error(`message lacks headers: ${message.id}`);
@@ -81,6 +81,7 @@ function convertMessage(message: Message): EmailResponse {
     from,
     subject,
     tags,
+    receivedAt,
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,8 +59,9 @@ function numPlucker(query: Query) {
 }
 
 function convertMessage(message: Message): EmailResponse {
-  // TODO: return real tags
-  const { id, gmailId, data } = message;
+  const {
+    id, gmailId, data, tags,
+  } = message;
   const headersRaw = data.payload?.headers;
   if (!headersRaw) throw new Error(`message lacks headers: ${message.id}`);
   const headers = headerPairsToHash(headersRaw);
@@ -75,8 +76,7 @@ function convertMessage(message: Message): EmailResponse {
     body,
     from,
     subject,
-    tags: ['fake-tag'],
-    suspicion: 0.01,
+    tags,
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,11 @@ async function createApp(): Promise<Express> {
     const pluck = numPlucker(req.query);
     const limit = pluck('limit', DEFAULT_PAGE_COUNT);
     const offset = pluck('offset', 0);
-    const messages = await Message.find({ take: limit, skip: offset });
+    const messages = await Message.find({
+      order: { receivedAt: 'DESC' },
+      take: limit,
+      skip: offset,
+    });
     const emails = messages.map((m) => convertMessage(m));
     res.json(emails);
   });

--- a/src/lib/classify.spec.ts
+++ b/src/lib/classify.spec.ts
@@ -118,49 +118,81 @@ describe('parseKeywordLists', () => {
       await readFile(join('fixtures', 'keywords.yaml'))
     ).toString();
     expect(parseKeywordLists(rawYaml)).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "name": "theft",
-          "phrases": Array [
-            "intellectual property",
-          ],
-          "threshold": 0.1,
-          "words": Array [
-            "ip",
-            "espionag",
-          ],
+      Object {
+        "keywords": Object {
+          "conspiracy": Object {
+            "description": "These suggest two or more people are conspirators.",
+            "keywords": Array [
+              "alliance",
+              "agreement",
+              "under the table",
+            ],
+            "threshold": 0.1,
+          },
+          "fraud": Object {
+            "description": "These suggest someone is committing some kind of fraud.",
+            "keywords": Array [
+              "pyramid",
+              "Ponzi",
+              "loophole",
+              "contract law",
+            ],
+            "threshold": 0.1,
+          },
+          "theft": Object {
+            "description": "These suggest someone is stealing something.",
+            "keywords": Array [
+              "IP",
+              "espionage",
+              "Intellectual Property",
+            ],
+            "threshold": 0.1,
+          },
         },
-        Object {
-          "name": "fraud",
-          "phrases": Array [
-            "contract law",
-          ],
-          "threshold": 0.1,
-          "words": Array [
-            "pyramid",
-            "ponzi",
-            "loophol",
-          ],
-        },
-        Object {
-          "name": "conspiracy",
-          "phrases": Array [
-            "under the table",
-          ],
-          "threshold": 0.1,
-          "words": Array [
-            "allianc",
-            "agreement",
-          ],
-        },
-      ]
+        "lists": Array [
+          Object {
+            "name": "theft",
+            "phrases": Array [
+              "intellectual property",
+            ],
+            "threshold": 0.1,
+            "words": Array [
+              "ip",
+              "espionag",
+            ],
+          },
+          Object {
+            "name": "fraud",
+            "phrases": Array [
+              "contract law",
+            ],
+            "threshold": 0.1,
+            "words": Array [
+              "pyramid",
+              "ponzi",
+              "loophol",
+            ],
+          },
+          Object {
+            "name": "conspiracy",
+            "phrases": Array [
+              "under the table",
+            ],
+            "threshold": 0.1,
+            "words": Array [
+              "allianc",
+              "agreement",
+            ],
+          },
+        ],
+      }
     `);
   });
 });
 
 describe('with a document and keyword list', () => {
   const rawYaml = readFileSync(join('fixtures', 'keywords.yaml')).toString();
-  const keywordLists = parseKeywordLists(rawYaml);
+  const keywordLists = parseKeywordLists(rawYaml).lists;
   const body = `
     Hey, did you perform that espionage I asked you about?
     The boss is asking for all the IP you stole. He wants the intellectual property badly.
@@ -239,7 +271,7 @@ describe('with the real keyword list and real emails', () => {
   const rawKeywords = readFileSync(
     join('resources', 'keywords.yaml'),
   ).toString();
-  const keywordLists = parseKeywordLists(rawKeywords);
+  const keywordLists = parseKeywordLists(rawKeywords).lists;
 
   type Email = { path: string; from: string; subject: string; body: string };
   const emailPaths: string[] = glob.sync('fixtures/emails/**/*.yaml');

--- a/src/lib/classify.ts
+++ b/src/lib/classify.ts
@@ -17,6 +17,7 @@ type BodyWithWordCounts = {
   wordCounts: { [word: string]: number };
 };
 
+type Keywords = { [name: string]: KeywordDetails };
 /**
  * The values for each key in the keywords file.
  */
@@ -96,10 +97,12 @@ function wordOrPhrase(item: string): 'word' | 'phrase' {
  * Parse the keywords YAML into Lists.
  * @param rawYaml The raw YAML from a keywords file
  */
-export function parseKeywordLists(rawYaml: string): List[] {
-  const rawObj: { [name: string]: KeywordDetails } = yaml.safeLoad(rawYaml);
+export function parseKeywordLists(
+  rawYaml: string,
+): { keywords: Keywords; lists: List[] } {
+  const keywords: Keywords = yaml.safeLoad(rawYaml);
   const lists: List[] = [];
-  Object.entries(rawObj).forEach(([name, details]) => {
+  Object.entries(keywords).forEach(([name, details]) => {
     const { threshold } = details;
     const words: string[] = [];
     const phrases: string[] = [];
@@ -118,7 +121,7 @@ export function parseKeywordLists(rawYaml: string): List[] {
       phrases,
     });
   });
-  return lists;
+  return { keywords, lists };
 }
 
 /**

--- a/src/lib/classify.ts
+++ b/src/lib/classify.ts
@@ -2,7 +2,7 @@
 import '../types/wink-porter2-stemmer';
 import stemmer from 'wink-porter2-stemmer';
 import yaml from 'js-yaml';
-import { StrNum } from '../types';
+import { StrNum, Keywords } from '../types';
 
 /** A list of keywords to be used for analyzing and tagging an email. */
 export type List = {
@@ -15,16 +15,6 @@ type BodyWithWordCounts = {
   body: string;
   words: string[];
   wordCounts: { [word: string]: number };
-};
-
-type Keywords = { [name: string]: KeywordDetails };
-/**
- * The values for each key in the keywords file.
- */
-type KeywordDetails = {
-  threshold: number;
-  description: string;
-  keywords: string[];
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,3 +23,16 @@ export interface EmailResponse {
   body?: string;
   data: Message;
 }
+
+/**
+ * The list of keywords used to analyze emails.
+ */
+export type Keywords = { [name: string]: KeywordDetails };
+/**
+ * The values for each type of keyword.
+ */
+export type KeywordDetails = {
+  threshold: number;
+  description: string;
+  keywords: string[];
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,8 +17,7 @@ export type MessagePartBody = GmailV1.Schema$MessagePartBody;
 export interface EmailResponse {
   id: number;
   gmailId: string;
-  tags: string[];
-  suspicion: number;
+  tags?: string[];
   from: string;
   subject: string;
   body?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export interface EmailResponse {
   subject: string;
   body?: string;
   data: Message;
+  receivedAt: Date;
 }
 
 /**

--- a/src/workers/classify.spec.ts
+++ b/src/workers/classify.spec.ts
@@ -5,6 +5,7 @@ import classify from './classify';
 import Message from '../entities/message';
 import { encode } from '../lib/util';
 import { parseKeywordLists, List } from '../lib/classify';
+import FAKE_RECEIVED_HEADERS from '../../fixtures/fake_received_headers.json';
 
 const messageFixtures = [
   // Empty; should be unclassifiable
@@ -13,7 +14,10 @@ const messageFixtures = [
   {
     gmailId: 'b',
     data: {
-      payload: { body: { data: encode('IP espionage intellectual property') } },
+      payload: {
+        headers: FAKE_RECEIVED_HEADERS,
+        body: { data: encode('IP espionage intellectual property') },
+      },
     },
   },
   // should be classified as "fraud"
@@ -21,6 +25,7 @@ const messageFixtures = [
     gmailId: 'c',
     data: {
       payload: {
+        headers: FAKE_RECEIVED_HEADERS,
         body: { data: encode('pyramid Ponzi loophole contract law') },
       },
     },
@@ -29,7 +34,10 @@ const messageFixtures = [
   {
     gmailId: 'd',
     data: {
-      payload: { body: { data: encode('under the table alliance agreement') } },
+      payload: {
+        headers: FAKE_RECEIVED_HEADERS,
+        body: { data: encode('under the table alliance agreement') },
+      },
     },
   },
 ];
@@ -40,6 +48,7 @@ function createMessages(): Promise<Message[]> {
       const m = new Message();
       m.gmailId = gmailId;
       m.data = data;
+      m.receivedAt = new Date();
       await m.save();
       return m;
     }),

--- a/src/workers/classify.spec.ts
+++ b/src/workers/classify.spec.ts
@@ -69,17 +69,17 @@ describe('message db tests', () => {
   });
 
   describe('classify', () => {
-    let keywordLists: List[];
+    let lists: List[];
     beforeEach(async () => {
       const rawYaml = readFileSync(
         join('fixtures', 'keywords.yaml'),
       ).toString();
-      keywordLists = parseKeywordLists(rawYaml);
+      lists = parseKeywordLists(rawYaml).lists;
       await createMessages();
     });
 
     it('classifies messages properly', async () => {
-      await classify(keywordLists);
+      await classify(lists);
       const empty = await Message.findOneOrFail({ gmailId: 'a' });
       const theft = await Message.findOneOrFail({ gmailId: 'b' });
       const fraud = await Message.findOneOrFail({ gmailId: 'c' });

--- a/src/workers/classify.ts
+++ b/src/workers/classify.ts
@@ -6,7 +6,7 @@ import { extractPlaintextContent } from '../lib/content';
 
 const BATCH_SIZE = 10;
 const RAW_KEYWORDS_PATH = join('resources', 'keywords.yaml');
-const RAW_KEYWORDS_YAML = readFileSync(RAW_KEYWORDS_PATH).toString();
+export const RAW_KEYWORDS_YAML = readFileSync(RAW_KEYWORDS_PATH).toString();
 
 async function persistTags(message: Message, tags: string[]): Promise<void> {
   const now = new Date();
@@ -40,7 +40,7 @@ async function classifyOne(message: Message, lists: List[]): Promise<void> {
  * successfully classified.
  */
 export default async function classify(lists?: List[]): Promise<number> {
-  const xLists = lists || (await parseKeywordLists(RAW_KEYWORDS_YAML));
+  const xLists = lists || (await parseKeywordLists(RAW_KEYWORDS_YAML)).lists;
   const toTag = await Message.find({
     take: BATCH_SIZE,
     where: { taggedAt: null },

--- a/src/workers/persist.spec.ts
+++ b/src/workers/persist.spec.ts
@@ -110,6 +110,17 @@ describe('message db tests', () => {
       );
     });
 
+    it('even parses weird Received headers', () => {
+      const value = 'from MTAzMzg1MDM (unknown) by geopod-ismtpd-5-0 (SG) with '
+        + 'HTTP id iz6CugXqRImzFy0ExSSbJQ Mon, 20 Apr 2020 21:17:19.253 +0000 (UTC)';
+      const msg = ({
+        payload: { headers: [{ name: 'Received', value }] },
+      } as unknown) as GmailMessage;
+      expect(parseReceivedHeader(msg)).toMatchInlineSnapshot(
+        '2020-04-20T21:17:19.253Z',
+      );
+    });
+
     it('throws when headers are missing', () => {
       const msg = ({} as unknown) as GmailMessage;
       expect(() => parseReceivedHeader(msg)).toThrowError(

--- a/src/workers/persist.ts
+++ b/src/workers/persist.ts
@@ -77,7 +77,7 @@ export function parseReceivedHeader(message: GmailMessage): Date {
   const headers = headerPairsToHash(raw);
 
   const receivedRaw = headers.Received;
-  const matcher = /;\s*(.+)/;
+  const matcher = /with \S+ id \S+;?\s*(.+)/;
   const match = receivedRaw.match(matcher);
   if (!match) throw new Error(`Cannot parse date: ${receivedRaw}`);
   const parsed = match[1];

--- a/src/workers/persist.ts
+++ b/src/workers/persist.ts
@@ -77,7 +77,7 @@ export function parseReceivedHeader(message: GmailMessage): Date {
   const headers = headerPairsToHash(raw);
 
   const receivedRaw = headers.Received;
-  const matcher = /;\s+(.+)/;
+  const matcher = /;\s*(.+)/;
   const match = receivedRaw.match(matcher);
   if (!match) throw new Error(`Cannot parse date: ${receivedRaw}`);
   const parsed = match[1];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,7 +37,8 @@
 
     "lib": ["es2017"],
     "types": ["node", "jest"],
-    "typeRoots": ["node_modules/@types", "src/types"]
+    "typeRoots": ["node_modules/@types", "src/types"],
+    "resolveJsonModule": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules/**"],


### PR DESCRIPTION
Present keyword descriptions and lists to the user when they view a tagged email.

* Add mandatory `receivedAt` property to Message and parse from `Received` header
* Sort messages endpoint by most recent first
* Fix test watcher running tests in parallel
* Expose entire keywords file to frontend