### PR TITLE
refactor: move gmail into lib

### DIFF
--- a/src/lib/gmail/__mocks__/api.ts
+++ b/src/lib/gmail/__mocks__/api.ts
@@ -1,5 +1,5 @@
-import { GmailClient, Message } from '../../types';
-import FAKE_RECEIVED_HEADERS from '../../../fixtures/fake_received_headers.json';
+import { GmailClient, Message } from '../../../types';
+import FAKE_RECEIVED_HEADERS from '../../../../fixtures/fake_received_headers.json';
 
 export async function listMessages(
   _client: GmailClient,

--- a/src/lib/gmail/api.ts
+++ b/src/lib/gmail/api.ts
@@ -1,4 +1,4 @@
-import { GmailClient, Thread, Message } from '../types';
+import { GmailClient, Thread, Message } from '../../types';
 
 /**
  * Get the first page of threads from the currently signed-in user's inbox.

--- a/src/workers/persist.spec.ts
+++ b/src/workers/persist.spec.ts
@@ -13,7 +13,7 @@ import { Message as GmailMessage, GmailClient } from '../types';
 import Message from '../entities/message';
 import FAKE_RECEIVED_HEADERS from '../../fixtures/fake_received_headers.json';
 
-jest.mock('../gmail/api');
+jest.mock('../lib/gmail/api');
 
 describe('castToSparse', () => {
   it('casts messages with ids to SparseMessages', () => {

--- a/src/workers/persist.ts
+++ b/src/workers/persist.ts
@@ -1,4 +1,4 @@
-import { getMessage, listMessages } from '../gmail/api';
+import { getMessage, listMessages } from '../lib/gmail/api';
 import { GmailClient, Message as GmailMessage } from '../types';
 import Message from '../entities/message';
 import { keepTruthy, headerPairsToHash } from '../lib/util';


### PR DESCRIPTION
Move the Gmail library code into `lib/`.